### PR TITLE
Do not prepend ->webroot to webroot-paths since this makes linking media-

### DIFF
--- a/views/helpers/media.php
+++ b/views/helpers/media.php
@@ -138,7 +138,7 @@ class MediaHelper extends AppHelper {
 		if (strpos($path, '://') !== false) {
 			return $path;
 		}
-		return $this->webroot . $path;
+		return '/' . $path;
 	}
 
 /**
@@ -212,7 +212,7 @@ class MediaHelper extends AppHelper {
 					$body .= sprintf(
 						$this->tags['source'],
 						$this->_parseAttributes(array(
-							'src' => $source['url'],
+							'src' => Router::url($source['url']),
 							'type' => $source['mimeType']
 					)));
 				}
@@ -230,7 +230,7 @@ class MediaHelper extends AppHelper {
 
 				return sprintf(
 					$this->Html->tags['image'],
-					$sources[0]['url'],
+					Router::url($sources[0]['url']),
 					$this->_parseAttributes($attributes)
 				);
 			case 'video':
@@ -240,7 +240,7 @@ class MediaHelper extends AppHelper {
 					$body .= sprintf(
 						$this->tags['source'],
 						$this->_parseAttributes(array(
-							'src' => $source['url'],
+							'src' => Router::url($source['url']),
 							'type' => $source['mimeType']
 					)));
 				}


### PR DESCRIPTION
Do not prepend ->webroot to webroot-paths since this makes linking media-files impossible. Instead, pass url's through Router::url() when embedding media.

When running a Cake-App inside a subfolder, links to mediafiles are broken. E.g. your cake-project resides under 'http://example.com/nicecakeapp/'. Then, in attachments.ctp around Line 120 $this->Html->link($item['basename'], $url) will result in the url http://example.com/nicecakeapp/nicecakeapp/media/transfer/bla.png being linked....
