### PR TITLE
Added windows compatibility to reading glob.db

### DIFF
--- a/libs/mm/src/Mime/Type/Glob/Adapter/Freedesktop.php
+++ b/libs/mm/src/Mime/Type/Glob/Adapter/Freedesktop.php
@@ -50,8 +50,7 @@ class Mime_Type_Glob_Adapter_Freedesktop extends Mime_Type_Glob_Adapter {
 	protected function _read($file) {
 		$handle = fopen($file, 'rb');
 
-		$itemRegex = '^(\d{2}:)?[-\w.+]*\/[-\w.+]+:[\*\.a-zA-Z0-9]*$';
-
+		$itemRegex = '^(\d{2}:)?[-\w.+]*\/[-\w.+]+:[\*\.a-zA-Z0-9]*\r?$';
 		if (!preg_match("/{$itemRegex}/m", fread($handle, 4096))) {
 			throw new InvalidArgumentException("File `{$file}` has wrong format");
 		}


### PR DESCRIPTION
When the Freedesktop.php adapter tries to read glob.db on a Windows machine, it doesn't pass the regexp (L 54) because of line ending issues differences. Adding the optional \r check to the end allows it to pass.
